### PR TITLE
error() to pd_error() fix for 0.52 compatibility

### DIFF
--- a/cavoc27~.c
+++ b/cavoc27~.c
@@ -135,7 +135,7 @@ void cavoc27_retune(t_cavoc27 *x, t_floatarg min, t_floatarg max)
     t_float *tmpchannel = x->tmpchannel;
     t_float *last_frame = x->last_frame;
     if( max <= 0 || min <= 0 || min > max ){
-        error("bad values for min and max multipliers");
+        pd_error(0, "bad values for min and max multipliers");
         return;
     }
     if( min < .1 )
@@ -182,7 +182,7 @@ void cavoc27_rule (t_cavoc27 *x, t_symbol *msg, short argc, t_atom *argv)
     int i;
     short *rule = x->rule;
     if( argc != 27 ){
-        error("the rule must be size 18");
+        pd_error(0, "the rule must be size 18");
         return;
     }
 
@@ -269,7 +269,7 @@ void cavoc27_init(t_cavoc27 *x)
     short initialized = fft->initialized;
     fftease_init(fft);
     if(! fft->R ){
-        error("cavoc27~: zero sampling rate!");
+        pd_error(0, "cavoc27~: zero sampling rate!");
         return;
     }
     x->frame_duration = (float)fft->D/(float) fft->R;
@@ -601,7 +601,7 @@ void cavoc27_hold_time(t_cavoc27 *x, t_floatarg hold_time)
         return;
     }
     if(! x->frame_duration){
-        error("%s: zero frame duration",OBJECT_NAME);
+        pd_error(0, "%s: zero frame duration",OBJECT_NAME);
         return;
     }
     x->hold_frames = (int) ( (x->hold_time/1000.0) / x->frame_duration);

--- a/cavoc~.c
+++ b/cavoc~.c
@@ -134,7 +134,7 @@ void cavoc_mute (t_cavoc *x, t_floatarg toggle)
 void cavoc_retune(t_cavoc *x, t_floatarg min, t_floatarg max)
 {
     if( max <= 0 || min <= 0 || min > max ){
-        error("bad values for min and max multipliers");
+        pd_error(0, "bad values for min and max multipliers");
         return;
     }
     if( min < .1 )
@@ -162,7 +162,7 @@ void cavoc_rule (t_cavoc *x, t_symbol *msg, short argc, t_atom *argv)
     int i;
     short *rule = x->rule;
     if( argc != 8 ){
-        error("the rule must be size 8");
+        pd_error(0, "the rule must be size 8");
         return;
     }
 
@@ -213,7 +213,7 @@ void cavoc_init(t_cavoc *x)
     fft->hi_bin = fft->N2 - 1;
 
     if(! fft->R ){
-        error("zero sampling rate!");
+        pd_error(0, "zero sampling rate!");
         return;
     }
     x->frame_duration = (float)fft->D/(float) fft->R;
@@ -281,7 +281,7 @@ void cavoc_topfreq(t_cavoc *x, t_floatarg tf)
 {
     t_fftease *fft = x->fft;
     if(tf < 100 || tf > fft->R / 2.0){
-        error("%s: top frequency out of range: %f",OBJECT_NAME,  tf);
+        pd_error(0, "%s: top frequency out of range: %f",OBJECT_NAME,  tf);
         return;
     }
     x->topfreq = (float) tf;
@@ -291,7 +291,7 @@ void cavoc_topfreq(t_cavoc *x, t_floatarg tf)
 void cavoc_bottomfreq(t_cavoc *x, t_floatarg bf)
 {
     if(bf < 0 && bf > x->topfreq){
-        error("%s: bottom frequency out of range: %f",OBJECT_NAME,  bf);
+        pd_error(0, "%s: bottom frequency out of range: %f",OBJECT_NAME,  bf);
         return;
     }
     x->bottomfreq = (float) bf;

--- a/dentist~.c
+++ b/dentist~.c
@@ -211,7 +211,7 @@ void dentist_init(t_dentist *x)
     x->max_bin = 1;
 
     if(!x->funda){
-        error("%s: zero sampling rate!",OBJECT_NAME);
+        pd_error(0, "%s: zero sampling rate!",OBJECT_NAME);
         return;
     }
     x->max_bin = (int) (x->topfreq / x->funda);
@@ -438,7 +438,7 @@ void dentist_toothcount(t_dentist *x, t_floatarg newcount)
         return;
     }
     if(nc < 0 || nc > x->fft->N2){
-        error("dentist~: %d out of range",nc);
+        pd_error(0, "dentist~: %d out of range",nc);
         return;
     }
 

--- a/disarrain~.c
+++ b/disarrain~.c
@@ -187,13 +187,13 @@ void disarrain_fadetime (t_disarrain *x, t_floatarg f)
         return;
     }
     if(x->frame_duration <= 0.0){
-        // error("%s: frame duration %f is too low", OBJECT_NAME, x->frame_duration);
+        // pd_error(0, "%s: frame duration %f is too low", OBJECT_NAME, x->frame_duration);
         return;
     }
     // duration = f * .001;
     frames = x->interpolation_duration / x->frame_duration;
     if( frames <= 1){
-        error("%s: fadetime too short",OBJECT_NAME);
+        pd_error(0, "%s: fadetime too short",OBJECT_NAME);
         return;
     }
     x->interpolation_frames = frames;
@@ -330,7 +330,7 @@ static void do_disarrain(t_disarrain *x)
             p1 = rand() % max;
             p2 = rand() % max;
             if(p1 < 0 || p1 > max || p2 < 0 || p2 > max){
-                error("disarrain~: bad remaps: %d %d against %d", p1, p2, max);
+                pd_error(0, "disarrain~: bad remaps: %d %d against %d", p1, p2, max);
             } else {
                 temp = shuffle_tmp[p1];
                 shuffle_tmp[ p1 ] = shuffle_tmp[ p2 ];
@@ -625,7 +625,7 @@ void disarrain_isetstate (t_disarrain *x, t_symbol *msg, short argc, t_atom *arg
         if ( ival < N2 && ival >= 0) {
             x->shuffle_mapping[ i ] = ival;
         }else {
-            error("%s: %d is out of range",OBJECT_NAME, ival);
+            pd_error(0, "%s: %d is out of range",OBJECT_NAME, ival);
         }
     }
 
@@ -644,7 +644,7 @@ void disarrain_setstate (t_disarrain *x, t_symbol *msg, short argc, t_atom *argv
         if ( ival < N2 && ival >= 0) {
             x->last_shuffle_mapping[i] = x->shuffle_mapping[i] = ival;
         } else {
-            error("%s: %d is out of range",OBJECT_NAME, ival);
+            pd_error(0, "%s: %d is out of range",OBJECT_NAME, ival);
         }
     }
     return;

--- a/disarray~.c
+++ b/disarray~.c
@@ -361,7 +361,7 @@ void disarray_setstate (t_disarray *x, t_symbol *msg, short argc, t_atom *argv) 
         if ( ival < x->fft->N2 && ival >= 0) {
             x->shuffle_out[ i ] = ival;
         } else {
-            error("%s: %d is out of range",OBJECT_NAME, ival);
+            pd_error(0, "%s: %d is out of range",OBJECT_NAME, ival);
         }
     }
 }

--- a/enrich~.c
+++ b/enrich~.c
@@ -101,7 +101,7 @@ void enrich_highfreq(t_enrich *x, t_floatarg f)
     float curfreq;
 
     if(f < x->lofreq){
-        error("current minimum is %f",x->lofreq);
+        pd_error(0, "current minimum is %f",x->lofreq);
         return;
     }
     if(f > fft->R/2 ){
@@ -122,7 +122,7 @@ void enrich_lowfreq(t_enrich *x, t_floatarg f)
     float curfreq;
 
     if(f > x->hifreq){
-        error("current maximum is %f",x->lofreq);
+        pd_error(0, "current maximum is %f",x->lofreq);
         return;
     }
     if(f < 0 ){

--- a/fftease_utilities.c
+++ b/fftease_utilities.c
@@ -53,7 +53,7 @@ int fftease_overlap( int overlap )
         target *= 2;
     }
     if( target != overlap ){
-        error("fftease_overlap: %d is not a legal overlap factor",overlap);
+        pd_error(0, "fftease_overlap: %d is not a legal overlap factor",overlap);
         return 1;
     }
     return overlap;
@@ -66,7 +66,7 @@ int fftease_winfac( int winfac)
         target *= 2;
     }
     if( target != winfac ){
-        // error("%d is not a legal window factor", winfac);
+        // pd_error(0, "%d is not a legal window factor", winfac);
         return 1;
     }
     return winfac;

--- a/loopsea~.c
+++ b/loopsea~.c
@@ -226,7 +226,7 @@ void loopsea_init(t_loopsea *x)
         for(i=0; i < x->framecount; i++){
             x->loveboat[i] = (t_float *) calloc((fft->N+2), sizeof(t_float));
             if(x->loveboat[i] == NULL){
-                error("%s: Insufficient Memory!",OBJECT_NAME);
+                pd_error(0, "%s: Insufficient Memory!",OBJECT_NAME);
                 return;
             }
         }
@@ -246,7 +246,7 @@ void loopsea_init(t_loopsea *x)
         for(i=0; i < x->framecount; i++){
             x->loveboat[i] = (t_float *) calloc((fft->N+2), sizeof(t_float));
             if(x->loveboat[i] == NULL){
-                error("%s: Insufficient Memory!",OBJECT_NAME);
+                pd_error(0, "%s: Insufficient Memory!",OBJECT_NAME);
                 return;
             }
         }
@@ -503,12 +503,12 @@ void loopsea_linephase(t_loopsea *x, t_symbol *msg, short argc, t_atom *argv)
     phase2 = atom_getfloatarg(3, argc, argv) * x->framecount;
 
     if( bin1 > fft->N2 || bin2 > fft->N2 ){
-        error("too high bin number");
+        pd_error(0, "too high bin number");
         return;
     }
     bindiff = bin2 - bin1;
     if( bindiff < 1 ){
-        error("make bin2 higher than bin 1, bye now");
+        pd_error(0, "make bin2 higher than bin 1, bye now");
         return;
     }
     for( i = bin1; i < bin2; i++ ){
@@ -665,12 +665,12 @@ void loopsea_linespeed(t_loopsea *x, t_symbol *msg, short argc, t_atom *argv)
     speed2 = atom_getfloatarg(3, argc, argv);
 
     if( bin1 > fft->N2 || bin2 > fft->N2 ){
-        error("too high bin number");
+        pd_error(0, "too high bin number");
         return;
     }
     bindiff = bin2 - bin1;
     if( bindiff < 1 ){
-        error("make bin2 higher than bin 1, bye now");
+        pd_error(0, "make bin2 higher than bin 1, bye now");
         return;
     }
     for( i = bin1; i < bin2; i++ ){

--- a/mindwarp~.c
+++ b/mindwarp~.c
@@ -135,13 +135,13 @@ static void do_mindwarp(t_mindwarp *x)
 
     warpFactor = x->warpFactor;
     if(warpFactor <= 0){
-        error("bad warp, resetting");
+        pd_error(0, "bad warp, resetting");
         warpFactor = 1.0;
     }
 
     newLength = (int) ((t_float) N2 / warpFactor);
     if(newLength <= 0){
-        error("bad length: resetting");
+        pd_error(0, "bad length: resetting");
         newLength = 1.0;
     }
 
@@ -216,7 +216,7 @@ static void do_mindwarp(t_mindwarp *x)
 
             // this can happen, crashing external; now fixed.
         if( freqSum <= 0 ) {
-                //      error("bad freq sum, resetting");
+                //      pd_error(0, "bad freq sum, resetting");
             freqSum = 1.0;
         }
         else
@@ -291,7 +291,7 @@ t_int *mindwarp_perform(t_int *w)
 
     if(x->warpFactor <= 0.0625){
         x->warpFactor = 1.0;
-    //     error("%s: zero warp factor is illegal",OBJECT_NAME);
+    //     pd_error(0, "%s: zero warp factor is illegal",OBJECT_NAME);
     }
     if( fft->bufferStatus == EQUAL_TO_MSP_VECTOR ){
         memcpy(input, input + D, (Nw - D) * sizeof(t_float));

--- a/pileup~.c
+++ b/pileup~.c
@@ -69,7 +69,7 @@ void pileup_highfreq(t_pileup *x, t_floatarg f)
     t_fftease *fft = x->fft;
 
     if(f < x->lo_freq){
-        error("current minimum is %f",x->lo_freq);
+        pd_error(0, "current minimum is %f",x->lo_freq);
         return;
     }
     if(f > fft->R/2 ){
@@ -90,7 +90,7 @@ void pileup_lowfreq(t_pileup *x, t_floatarg f)
     t_fftease *fft = x->fft;
 
     if(f > x->hi_freq){
-        error("current maximum is %f",x->lo_freq);
+        pd_error(0, "current maximum is %f",x->lo_freq);
         return;
     }
     if(f < 0 ){

--- a/pvcompand~.c
+++ b/pvcompand~.c
@@ -121,7 +121,7 @@ void update_thresholds( t_pvcompand *x ) {
             nowamp += x->gstep ;
             ++(x->count);
             if(x->count >= N){
-                error("count exceeds %d",N);
+                pd_error(0, "count exceeds %d",N);
                 x->count = N - 1;
                 break;
             }
@@ -133,7 +133,7 @@ void update_thresholds( t_pvcompand *x ) {
             nowamp -= x->gstep ;
             ++(x->count);
             if(x->count >= N){
-                error("count exceeds %d",N);
+                pd_error(0, "count exceeds %d",N);
                 x->count = N - 1;
                 break;
             }

--- a/pvgrain~.c
+++ b/pvgrain~.c
@@ -244,7 +244,7 @@ static void do_pvgrain(t_pvgrain *x)
         print_grain = 1;
         dice = fftease_randf(0.,1.);
         if( dice < 0.0 || dice > 1.0 ){
-            error("dice %f out of range", dice);
+            pd_error(0, "dice %f out of range", dice);
         }
         if( selection_probability < 1.0 ){
             if( dice > selection_probability) {

--- a/pvharm~.c
+++ b/pvharm~.c
@@ -66,7 +66,7 @@ void pvharm_lowfreq(t_pvharm *x, t_floatarg f)
     int R = x->fft->R;
     if(R > 0){
         if(f > x->hifreq){
-            error("%s: minimum cannot exceed current maximum: %f",OBJECT_NAME,x->hifreq);
+            pd_error(0, "%s: minimum cannot exceed current maximum: %f",OBJECT_NAME,x->hifreq);
             return;
         }
         if(f < 0 ){
@@ -87,7 +87,7 @@ void pvharm_highfreq(t_pvharm *x, t_floatarg f)
     int R = x->fft->R;
     if(R > 0){
         if(f < x->lofreq){
-            error("%s: maximum cannot go below current minimum: %f",OBJECT_NAME,x->lofreq);
+            pd_error(0, "%s: maximum cannot go below current minimum: %f",OBJECT_NAME,x->lofreq);
             return;
         }
         if(f > R/2 ){

--- a/pvoc~.c
+++ b/pvoc~.c
@@ -68,7 +68,7 @@ void pvoc_highfreq(t_pvoc *x, t_floatarg f)
         f = 0;
     }
     if(f < x->lofreq){
-        error("%s: maximum cannot go below current minimum: %f",OBJECT_NAME,x->lofreq);
+        pd_error(0, "%s: maximum cannot go below current minimum: %f",OBJECT_NAME,x->lofreq);
         return;
     }
     if(f > x->fft->R/2 ){

--- a/pvtuner~.c
+++ b/pvtuner~.c
@@ -222,7 +222,7 @@ void pvtuner_toptune(t_pvtuner *x, t_floatarg f)
     curfreq = 0;
 
     if( f < 0 || f > x->fft->R / 2.0 ){
-        error("frequency %f out of range", f);
+        pd_error(0, "frequency %f out of range", f);
         return;
     }
     while( curfreq < f ) {
@@ -232,7 +232,7 @@ void pvtuner_toptune(t_pvtuner *x, t_floatarg f)
     if( tbin > fft->lo_bin && tbin <= fft->hi_bin ){
         x->hi_tune_bin = tbin;
     } else {
-        error("pvtuner~: bin %d out of range", tbin);
+        pd_error(0, "pvtuner~: bin %d out of range", tbin);
     }
 
 }
@@ -246,7 +246,7 @@ void pvtuner_list (t_pvtuner *x, t_symbol *msg, short argc, t_atom *argv)
     int i = 0;
 
     if( ! atom_getfloatarg(i,argc,argv) ){
-        error("either zero length scale or 0.0 (prohibited) is first value");
+        pd_error(0, "either zero length scale or 0.0 (prohibited) is first value");
         return;
     }
     pvtuner_copy_scale(x);
@@ -278,7 +278,7 @@ void pvtuner_frequency_range(t_pvtuner *x, t_floatarg lo, t_floatarg hi)
 
 
     if( lo >= hi ){
-        error("low frequency must be lower than high frequency");
+        pd_error(0, "low frequency must be lower than high frequency");
         return;
     }
     x->curfreq = 0;
@@ -524,7 +524,7 @@ void pvtuner_update_imported( t_pvtuner *x ){
     int i;
 
     if( pitchgrid[0] <= 0.0){
-        error("%s: illegal first value of scale: %f",OBJECT_NAME,pitchgrid[0]);
+        pd_error(0, "%s: illegal first value of scale: %f",OBJECT_NAME,pitchgrid[0]);
         return;
     }
 

--- a/pvwarpb~.c
+++ b/pvwarpb~.c
@@ -314,7 +314,7 @@ void pvwarpb_bottomfreq(t_pvwarpb *x, t_floatarg f)
         return;
     }
     if( f < 0 || f > x->fft->R / 2.0 ){
-        error("%s: frequency %f out of range", OBJECT_NAME, f);
+        pd_error(0, "%s: frequency %f out of range", OBJECT_NAME, f);
         return;
     }
     x->lofreq = f;
@@ -330,7 +330,7 @@ void pvwarpb_topfreq(t_pvwarpb *x, t_floatarg f)
         return;
     }
     if( f < x->lofreq || f > x->fft->R / 2.0 ){
-        error("%s: frequency %f out of range", OBJECT_NAME, f);
+        pd_error(0, "%s: frequency %f out of range", OBJECT_NAME, f);
         return;
     }
     x->hifreq = f;

--- a/pvwarp~.c
+++ b/pvwarp~.c
@@ -259,7 +259,7 @@ void pvwarp_bottomfreq(t_pvwarp *x, t_floatarg f)
         return;
     }
     if( f < 0 || f > x->fft->R / 2.0 ){
-        error("%s: frequency %f out of range", OBJECT_NAME, f);
+        pd_error(0, "%s: frequency %f out of range", OBJECT_NAME, f);
         return;
     }
     x->lofreq = f;
@@ -275,7 +275,7 @@ void pvwarp_topfreq(t_pvwarp *x, t_floatarg f)
         return;
     }
     if( f < x->lofreq || f > x->fft->R / 2.0 ){
-        error("%s: frequency %f out of range", OBJECT_NAME, f);
+        pd_error(0, "%s: frequency %f out of range", OBJECT_NAME, f);
         return;
     }
     x->hifreq = f;

--- a/resent~.c
+++ b/resent~.c
@@ -303,7 +303,7 @@ void resent_init(t_resent *x)
         for(i=0; i < x->framecount; i++){
             x->loveboat[i] = (t_float *) calloc((fft->N+2), sizeof(t_float));
             if(x->loveboat[i] == NULL){
-                error("%s: Insufficient Memory!",OBJECT_NAME);
+                pd_error(0, "%s: Insufficient Memory!",OBJECT_NAME);
                 return;
             }
         }
@@ -320,7 +320,7 @@ void resent_init(t_resent *x)
         for(i=0; i < x->framecount; i++){
             x->loveboat[i] = (t_float *) calloc((fft->N+2), sizeof(t_float));
             if(x->loveboat[i] == NULL){
-                error("%s: Insufficient Memory!",OBJECT_NAME);
+                pd_error(0, "%s: Insufficient Memory!",OBJECT_NAME);
                 return;
             }
         }
@@ -560,12 +560,12 @@ void resent_linephase(t_resent *x, t_symbol *msg, short argc, t_atom *argv)
     phase2 = atom_getfloatarg(3, argc, argv) * x->framecount;
 
     if( bin1 > fft->N2 || bin2 > fft->N2 ){
-        error("too high bin number");
+        pd_error(0, "too high bin number");
         return;
     }
     bindiff = bin2 - bin1;
     if( bindiff < 1 ){
-        error("make bin2 higher than bin 1, bye now");
+        pd_error(0, "make bin2 higher than bin 1, bye now");
         return;
     }
     for( i = bin1; i < bin2; i++ ){
@@ -627,12 +627,12 @@ void resent_linespeed(t_resent *x, t_symbol *msg, short argc, t_atom *argv)
     speed2 = atom_getfloatarg(3, argc, argv);
 
     if( bin1 > fft->N2 || bin2 > fft->N2 ){
-        error("too high bin number");
+        pd_error(0, "too high bin number");
         return;
     }
     bindiff = bin2 - bin1;
     if( bindiff < 1 ){
-        error("make bin2 higher than bin 1, bye now");
+        pd_error(0, "make bin2 higher than bin 1, bye now");
         return;
     }
     for( i = bin1; i < bin2; i++ ){

--- a/residency~.c
+++ b/residency~.c
@@ -217,7 +217,7 @@ void residency_init(t_residency *x)
         for(i=0;i < x->framecount; i++){
             x->loveboat[i] = (t_float *) calloc((fft->N + 2), sizeof(t_float));
             if(x->loveboat[i] == NULL){
-                error("%s: memory error",OBJECT_NAME);
+                pd_error(0, "%s: memory error",OBJECT_NAME);
                 return;
             }
         }
@@ -236,7 +236,7 @@ void residency_init(t_residency *x)
             for(i=0;i < x->framecount; i++){
                 x->loveboat[i] = (t_float *) calloc((fft->N + 2), sizeof(t_float));
                 if(x->loveboat[i] == NULL){
-                    error("%s: memory error",OBJECT_NAME);
+                    pd_error(0, "%s: memory error",OBJECT_NAME);
                     return;
                 }
             }
@@ -251,7 +251,7 @@ void residency_init(t_residency *x)
         x->failed_init = 0;
     }
     if (fft->D <= 0.0 || fft->R <= 0.0){
-        error("%s: bad decimation size or bad sampling rate - cannot proceed",OBJECT_NAME);
+        pd_error(0, "%s: bad decimation size or bad sampling rate - cannot proceed",OBJECT_NAME);
         post("D: %d R: %d",fft->D, fft->R);
         return;
     }


### PR DESCRIPTION
Same fix as for pd-lyonpotpourri:

Apply following search and replace to files to apply 0.52 fix for `error()`

```
rpl -R -x ".c" " error(" " pd_error(0, " .
```